### PR TITLE
feat: Integrate inference service URL into Helm chart

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
           value: "{{ .Values.minio.browser }}"
         - name: MINIO_CONSOLE_ADDRESS
           value: "{{ .Values.minio.consoleAddress }}"
+        - name: INFERENCE_SERVICE_URL
+          value: "{{ .Values.inferenceServiceUrl }}"
         ports:
         - containerPort: 9000
           name: api

--- a/values.yaml
+++ b/values.yaml
@@ -17,3 +17,5 @@ resources:
 
 storage:
   size: 1Gi
+
+inferenceServiceUrl: http://triton.runai-test.svc.cluster.local


### PR DESCRIPTION
Adds the ability to configure an inference service URL for the application deployed by this Helm chart.

Modifications:
- Added `inferenceServiceUrl` to `values.yaml` with a default value.
- Updated `templates/deployment.yaml` to expose this URL to the application container via an `INFERENCE_SERVICE_URL` environment variable.

This allows the deployed application to dynamically connect to the specified inference service, such as a Triton server running in the same Run:AI cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring an inference service URL via a new environment variable.
  - Introduced a new configuration option to set the inference service URL in the deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->