### PR TITLE
feat: Allow using an existing PersistentVolumeClaim

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -40,4 +40,4 @@ spec:
       volumes:
       - name: minio-storage
         persistentVolumeClaim:
-          claimName: minio-pvc
+          claimName: {{ .Values.minio.existingClaim | default "minio-pvc" }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.minio.existingClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,3 +9,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size }}
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,7 @@ minio:
   rootPassword: minioadmin123
   browser: "on"
   consoleAddress: ":9090"
+  existingClaim: ""
 
 resources:
   requests:


### PR DESCRIPTION
I've modified the Helm chart to enable you to use a pre-existing PVC for MinIO storage.

Here are the changes:
- I added `minio.existingClaim` to `values.yaml`. If you provide this value, the chart will use the specified existing PVC.
- `templates/pvc.yaml` is now conditional and will only create a new PVC if you don't set `minio.existingClaim`.
- `templates/deployment.yaml` now uses the value of `minio.existingClaim` for the `claimName` if you provide it, defaulting to 'minio-pvc' otherwise.

This will give you more flexibility if you have pre-provisioned storage or need to reuse existing PVCs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an existing PersistentVolumeClaim (PVC) for MinIO deployments via a new configuration option.
- **Chores**
  - Improved Helm chart flexibility by conditionally creating a PVC only when an existing claim is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->